### PR TITLE
Fixes for #2 and multiline moves past edges of buffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "moveline"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Will Hopkins <willothyh@gmail.com>"]
 description = "A neovim plugin to move lines up and down"


### PR DESCRIPTION
* Attempting to move a line past the edge of a buffer will no longer error. Trying to move past the start or end of a buffer will move the line to the end of the file as expected instead of erroring.

* Fixes #2 
