### PR TITLE
fix: move rustflags to cargo config file

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,3 @@ crate-type = ["cdylib"]
 [dependencies]
 nvim-utils = { version = "0.1.12" }
 mlua = { version = "0.8.7", features = ["luajit", "vendored", "module"] }
-
-[target.x86_64-apple-darwin]
-rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
-
-[target.aarch64-apple-darwin]
-rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]


### PR DESCRIPTION
This PR moves the rustflags settings into `.cargo/config.toml` file, see [this](https://doc.rust-lang.org/cargo/reference/config.html).

By default (with the rustflags in Cargo.toml), I had the same error as described in #5, with the latest rust tool chains installed.

This also allows successful build on macOS arm64 (tested locally on M1 Max), close #5.
